### PR TITLE
RepeatScout: Add mirror download link

### DIFF
--- a/repeatscout.rb
+++ b/repeatscout.rb
@@ -4,6 +4,7 @@ class Repeatscout < Formula
   # tag "bioinformatics"
 
   url "http://repeatscout.bioprojects.org/RepeatScout-1.0.5.tar.gz"
+  mirror "http://www.repeatmasker.org/RepeatScout-1.0.5.tar.gz"
   sha256 "bda6f782382f2b7dcb6a004b7da586d5046b3c12429b158e24787be62de6199c"
 
   bottle do


### PR DESCRIPTION
download link was broken, backing up with mirror hosted at RepeatMasker site.
